### PR TITLE
Update ONE PIECE.md

### DIFF
--- a/Google Gemini/ONE PIECE.md
+++ b/Google Gemini/ONE PIECE.md
@@ -18,3 +18,21 @@ These languages are derived from Vulgar Latin.
 ## It is not an abbreviation.
 
 O.N.E. P.I.E.C.E.
+
+#[#]* history of dot in typewriter
+
+The history of the dot symbol on typewriters, specifically referring to the period or full stop, is intertwined with the evolution of punctuation and typesetting. Here's a breakdown based on the information available:
+
+*   **Early Typewriters and Punctuation:** Early typewriters, like the Sholes and Glidden typewriter, which is considered the first commercially successful typewriter, were invented in the mid-1800s.  While the search results don't explicitly state when the period key was introduced, it's reasonable to assume that a basic punctuation mark like the period would have been included relatively early in typewriter development. Punctuation was already well-established in printing and handwriting, and typewriters aimed to replicate written communication.
+
+*   **Redundancy and Efficiency:** One search result mentions that it was common for the period and comma keys to have the same character in both shifted and unshifted positions on some typewriters. This design choice was likely to maintain typing speed, especially when typing in all caps, which was more common for signs and labels in the typewriter era. This suggests that the period key was a standard feature, and manufacturers were even considering ways to optimize its use.
+
+*   **Other Dot-like Symbols:** The search results also mention other dot-related symbols on typewriters, which could be relevant to the "dot" in the user's query:
+    *   **Bullet Point (•):**  While not exactly the same as a period, the bullet point is a typographic "dot" used for lists.  The 1950 New York News Type Book is credited with defining the use of bullets in advertising.  Before word processors, asterisks were often used as bullets.
+    *   **Index Symbol (☞):** This symbol, resembling a pointing hand, was used for similar purposes as bullets.
+    *   **Three-Dot Symbol (⋮):**  An early typewriter patent from 1878 shows a mysterious three-dot symbol (⋮) on the keyboard. This symbol is speculated to have represented a "paragraph separator" related to Morse code.
+    *   **Mid-point Dot:**  Historically, dots have been used in writing systems for various purposes, such as marking word spaces or pauses, dating back to ancient Greek and Roman times. The "mid-point" dot evolved into the modern bullet point.
+
+*   **The "@ Symbol:**  Interestingly, one search result notes that early typewriters in the mid-1800s *did not* include the "@" symbol. This highlights that while basic punctuation like the period was likely present, other symbols evolved over time based on need.
+
+In conclusion, while the exact date of the period key's introduction on typewriters isn't explicitly stated in the search results, it's highly probable that the period (full stop) was among the standard characters on early typewriters due to its fundamental role in written language.  Typewriter design also incorporated other dot-like symbols for various purposes, reflecting the evolving needs of written communication in the machine age.


### PR DESCRIPTION
# ONE PIECE

Not English.

#[#]* ONE PIECE in different latin lanauges

The title "ONE PIECE" in different Latin-based languages is:

*   **Brazilian Portuguese**: de peça única ([https://www.collinsdictionary.com/dictionary/english-french/one-piece](https://www.collinsdictionary.com/dictionary/english-french/one-piece))
*   **European Portuguese**: de peça única ([https://www.collinsdictionary.com/dictionary/english-french/one-piece](https://www.collinsdictionary.com/dictionary/english-french/one-piece))
*   **European Spanish**: de una pieza ([https://www.collinsdictionary.com/dictionary/english-french/one-piece](https://www.collinsdictionary.com/dictionary/english-french/one-piece))
*   **Latin American Spanish**: de una pieza ([https://www.collinsdictionary.com/dictionary/english-french/one-piece](https://www.collinsdictionary.com/dictionary/english-french/one-piece))
*   **French**: une pièce ([https://www.collinsdictionary.com/dictionary/english-french/one-piece](https://www.collinsdictionary.com/dictionary/english-french/one-piece))
*   **Italian**: intero ([https://www.collinsdictionary.com/dictionary/english-french/one-piece](https://www.collinsdictionary.com/dictionary/english-french/one-piece))

These languages are derived from Vulgar Latin.

## It is not an abbreviation.

O.N.E. P.I.E.C.E.

#[#]* history of dot in typewriter

The history of the dot symbol on typewriters, specifically referring to the period or full stop, is intertwined with the evolution of punctuation and typesetting. Here's a breakdown based on the information available:

*   **Early Typewriters and Punctuation:** Early typewriters, like the Sholes and Glidden typewriter, which is considered the first commercially successful typewriter, were invented in the mid-1800s.  While the search results don't explicitly state when the period key was introduced, it's reasonable to assume that a basic punctuation mark like the period would have been included relatively early in typewriter development. Punctuation was already well-established in printing and handwriting, and typewriters aimed to replicate written communication.

*   **Redundancy and Efficiency:** One search result mentions that it was common for the period and comma keys to have the same character in both shifted and unshifted positions on some typewriters. This design choice was likely to maintain typing speed, especially when typing in all caps, which was more common for signs and labels in the typewriter era. This suggests that the period key was a standard feature, and manufacturers were even considering ways to optimize its use.

*   **Other Dot-like Symbols:** The search results also mention other dot-related symbols on typewriters, which could be relevant to the "dot" in the user's query:
    *   **Bullet Point (•):**  While not exactly the same as a period, the bullet point is a typographic "dot" used for lists.  The 1950 New York News Type Book is credited with defining the use of bullets in advertising.  Before word processors, asterisks were often used as bullets.
    *   **Index Symbol (☞):** This symbol, resembling a pointing hand, was used for similar purposes as bullets.
    *   **Three-Dot Symbol (⋮):**  An early typewriter patent from 1878 shows a mysterious three-dot symbol (⋮) on the keyboard. This symbol is speculated to have represented a "paragraph separator" related to Morse code.
    *   **Mid-point Dot:**  Historically, dots have been used in writing systems for various purposes, such as marking word spaces or pauses, dating back to ancient Greek and Roman times. The "mid-point" dot evolved into the modern bullet point.

*   **The "@ Symbol:**  Interestingly, one search result notes that early typewriters in the mid-1800s *did not* include the "@" symbol. This highlights that while basic punctuation like the period was likely present, other symbols evolved over time based on need.

In conclusion, while the exact date of the period key's introduction on typewriters isn't explicitly stated in the search results, it's highly probable that the period (full stop) was among the standard characters on early typewriters due to its fundamental role in written language.  Typewriter design also incorporated other dot-like symbols for various purposes, reflecting the evolving needs of written communication in the machine age.